### PR TITLE
update code to reflect readme docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,13 @@ module.exports = parseStream
 
 function parseStream (opts) {
   if (!opts) opts = {}
-  if (opts.format === 'csv') return parseCSV(opts.separator)
-  if (opts.format === 'tsv') return parseCSV('\t')
-  if (opts.format === 'json') return parseJSON(opts.jsonpath)
-  if (opts.format === 'objects') return parseObjects()
+  
+  switch (opts.format || opts.f) {
+    case 'csv': return parseCSV(opts.separator)
+    case 'tsv': return parseCSV('\t')
+    case 'json': return parseJSON(opts.jsonpath)
+    case 'objects': return parseObjects()
+  }
 
   var detectMax = opts.detectMax || 8000
 

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ module.exports = parseStream
 
 function parseStream (opts) {
   if (!opts) opts = {}
-  if (opts.f === 'csv') return parseCSV(opts.separator)
-  if (opts.f === 'tsv') return parseCSV('\t')
-  if (opts.f === 'json') return parseJSON(opts.jsonpath)
-  if (opts.f === 'objects') return parseObjects()
+  if (opts.format === 'csv') return parseCSV(opts.separator)
+  if (opts.format === 'tsv') return parseCSV('\t')
+  if (opts.format === 'json') return parseJSON(opts.jsonpath)
+  if (opts.format === 'objects') return parseObjects()
 
   var detectMax = opts.detectMax || 8000
 


### PR DESCRIPTION
hey :space_invader:

not sure if i'm missing something, but seems the code doesn't reflect the readme docs? this change from using `opts.f` to using `opts.format` as described in [readme.md#options](https://github.com/karissa/parse-input-stream#options) should fix that. :smile: 
